### PR TITLE
Add action node management functionality and update version to 17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ducopy"
-version = "16"  # Adjust as needed
+version = "17"  # Adjust as needed
 description = "DucoPy: A Python library and CLI for full control over DucoBox ventilation units with a Connectivity Board. Retrieve system info, manage configurations, control nodes, and monitor logs easily from your Python environment or command line. "
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ducopy/cli.py
+++ b/src/ducopy/cli.py
@@ -130,6 +130,35 @@ def raw_get(
 
 
 @app.command()
+def change_action_node(
+    base_url: str,
+    node_id: int,
+    action: Annotated[str, typer.Option(help="The action key to include in the JSON body")],
+    value: Annotated[str, typer.Option(help="The value key to include in the JSON body")],
+    format: Annotated[str, typer.Option(help="Output format: pretty or json")] = "pretty",
+) -> None:
+    """
+    Perform a POST action by sending a JSON body to the endpoint.
+
+    Args:
+        base_url (str): The base URL of the API.
+        node_id (int): The ID of the node to perform the action on.
+        action (str): The action key to include in the JSON body.
+        value (str): The value key to include in the JSON body.
+        format (str): Output format: pretty or json.
+    """
+    base_url = validate_url(base_url)
+    facade = DucoPy(base_url)
+    try:
+        response = facade.change_action_node(action=action, value=value, node_id=node_id)
+        print_output(response, format)
+    except Exception as e:
+        logger.error("Error performing POST action for node {}: {}", node_id, e)
+        typer.echo(f"Failed to perform POST action for node {node_id}: {e}")
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def update_config_node(
     base_url: str,
     node_id: int,

--- a/src/ducopy/ducopy.py
+++ b/src/ducopy/ducopy.py
@@ -41,6 +41,7 @@ from ducopy.rest.models import (
     ActionsResponse,
     ConfigNodeRequest,
     NodesInfoResponse,
+    ActionsChangeResponse
 )
 from pydantic import HttpUrl
 
@@ -51,6 +52,9 @@ class DucoPy:
 
     def raw_get(self, endpoint: str, params: dict = None) -> dict:
         return self.client.raw_get(endpoint=endpoint, params=params)
+    
+    def change_action_node(self, action: str, value: str, node_id: int) -> ActionsChangeResponse:
+        return self.client.post_action_node(action, value, node_id)
 
     def update_config_node(self, node_id: int, config: ConfigNodeRequest) -> ConfigNodeResponse:
         return self.client.patch_config_node(node_id=node_id, config=config)

--- a/src/ducopy/rest/models.py
+++ b/src/ducopy/rest/models.py
@@ -262,3 +262,8 @@ class ActionInfo(BaseModel):
 class ActionsResponse(BaseModel):
     Node: int
     Actions: list[ActionInfo]
+
+
+class ActionsChangeResponse(BaseModel):
+    Code: int
+    Result: str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import requests_mock
 import json
 from typing import Any
 from ducopy.rest.client import APIClient
-from ducopy.rest.models import NodeInfo, ConfigNodeResponse, ActionsResponse, NodesInfoResponse
+from ducopy.rest.models import NodeInfo, ConfigNodeResponse, ActionsResponse, NodesInfoResponse, ActionsChangeResponse
 
 BASE_URL = "http://localhost:5000"
 
@@ -53,6 +53,17 @@ def test_get_nodes(client: APIClient, mock_requests: requests_mock.Mocker) -> No
     nodes_response = NodesInfoResponse(**mock_data)  # Instantiate NodesInfoResponse directly with data
     assert isinstance(nodes_response, NodesInfoResponse)
     assert len(nodes_response.Nodes) == len(mock_data["Nodes"])
+
+
+def test_post_action_node(client: APIClient, mock_requests: requests_mock.Mocker) -> None:
+    mock_info_endpoint(mock_requests)
+    mock_data = load_mock_data("set_actions_node_1.json")
+    mock_requests.post(f"{BASE_URL}/action/nodes/1", json=mock_data)
+
+    action_response = ActionsChangeResponse(**mock_data)  # Instantiate ActionsChangeResponse directly with data
+    assert isinstance(action_response, ActionsChangeResponse)
+    assert action_response.Code == mock_data["Code"]
+    assert action_response.Result == mock_data["Result"]
 
 
 def test_get_node_info(client: APIClient, mock_requests: requests_mock.Mocker) -> None:

--- a/tests/test_data/set_actions_node_1.json
+++ b/tests/test_data/set_actions_node_1.json
@@ -1,0 +1,4 @@
+{
+    "Code": 0, 
+    "Result": "SUCCESS"
+}

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from ducopy.rest.client import APIClient
-from ducopy.rest.models import NodeInfo, ConfigNodeResponse, ActionsResponse, NodesInfoResponse
+from ducopy.rest.models import NodeInfo, ConfigNodeResponse, ActionsResponse, NodesInfoResponse, ActionsChangeResponse
 
 
 @pytest.fixture(scope="module")
@@ -82,6 +82,22 @@ def test_get_config_node_insecure(client_insecure: APIClient) -> None:
     config_node_response = client_insecure.get_config_node(node_id=1)
     assert isinstance(config_node_response, ConfigNodeResponse), "Expected ConfigNodeResponse instance"
     assert config_node_response.Node == 1, "Config node response should match node ID 1"
+
+
+def test_set_actions_node(client: APIClient) -> None:
+    """Test setting actions for a specific node action with SSL verification."""
+    set_action_response = client.post_action_node(action="SetVentilationState", value="MAN1", node_id=1)
+    assert isinstance(set_action_response, ActionsChangeResponse), "Expected ActionsChangeResponse instance"
+    assert set_action_response.Code == 0, "Action response code should be 0"
+    assert set_action_response.Result == "SUCCESS", "Action response result should be SUCCESS"
+
+
+def test_set_actions_node_insecure(client_insecure: APIClient) -> None:
+    """Test fetching configuration settings for a specific node with SSL verification."""
+    set_action_response = client_insecure.post_action_node(action="SetVentilationState", value="MAN1", node_id=1)
+    assert isinstance(set_action_response, ActionsChangeResponse), "Expected ActionsChangeResponse instance"
+    assert set_action_response.Code == 0, "Action response code should be 0"
+    assert set_action_response.Result == "SUCCESS", "Action response result should be SUCCESS"
 
 
 def test_get_logs(client: APIClient) -> None:


### PR DESCRIPTION
- Implemented `change_action_node` command in CLI for performing actions on nodes.
- Added `post_action_node` method in APIClient to handle POST requests for node actions.
- Introduced `ActionsChangeResponse` model for structured response handling.
- Updated tests to cover new action node functionality.

This PR will help with the Home Assistant Plugin we have made. We will be able to boost the ventilation (Night Cooling, etc) with this PR

It will also do some basic validation and check that the controller supports the action and value that is being requested.

New commands available
```
ducopy change-action-node https://<ip_address>/ 1 --action=SetVentilationState --value=AUTO
```