### PR TITLE
feat: Add logging configuration to DucoPy class

### DIFF
--- a/src/ducopy/ducopy.py
+++ b/src/ducopy/ducopy.py
@@ -43,20 +43,44 @@ from ducopy.rest.models import (
     NodesInfoResponse,
     ActionsChangeResponse,
 )
+from loguru import logger
 from pydantic import HttpUrl
+import sys
 
 
 class DucoPy:
     """A facade for interacting with the Duco API."""
 
-    def __init__(self, base_url: HttpUrl, verify: bool = True) -> None:
+    def __init__(self, base_url: HttpUrl, verify: bool = True, log_level: str = None) -> None:
         """Initialize the DucoPy facade with the base URL and verification option.
 
         Args:
             base_url (HttpUrl): The base URL of the Duco API.
             verify (bool, optional): Whether to verify SSL certificates. Defaults to True.
+            log_level (str, optional): Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL). Defaults to None.
         """
+        if log_level is not None:
+            self.configure_logging(log_level)
+        
         self.client = APIClient(base_url, verify)
+        logger.info("Initialized DucoPy with base URL: {}", base_url)
+
+    @classmethod
+    def configure_logging(cls, level: str = "INFO", sink: object = sys.stdout) -> None:
+        """Configure logging for the DucoPy library.
+        
+        Args:
+            level (str): Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+            sink: Where to output logs (default: sys.stdout)
+            format_string (str): Custom format string for log messages
+        """
+        logger.remove()
+        
+        logger.add(
+            sink=sink,
+            level=level.upper(),
+        )
+        logger.info("DucoPy logging configured with level: {}", level)
 
     def raw_post(self, endpoint: str, data: str | None = None) -> dict:
         """Perform a raw POST request to the specified endpoint.


### PR DESCRIPTION
This pull request introduces logging capabilities to the `DucoPy` library similar to what is available to the CLI, allowing users to configure log output and levels for better observability. The main change is the addition of a `configure_logging` method, which can be invoked via the constructor or directly as a class method.

**Logging integration and configuration:**

* Updated the `DucoPy` constructor to accept an optional `log_level` parameter, allowing users to set the desired logging level when initializing the facade.
* Implemented a `configure_logging` class method that sets up logging output, log level, and sink (defaulting to `sys.stdout`), making logging flexible and customizable.
* Added log statements to indicate when logging is configured and when the `DucoPy` instance is initialized, improving traceability and debugging.