### PR TITLE
change NodeInfo model to support outdoor temperature sensor

### DIFF
--- a/src/ducopy/rest/client.py
+++ b/src/ducopy/rest/client.py
@@ -240,7 +240,7 @@ class APIClient:
         # Send PATCH request if validation passes
         endpoint = f"/config/nodes/{node_id}"
         logger.info("Sending PATCH request with body: {}", request_body)
-        response = self.session.patch(endpoint, json=request_body)
+        response = self.session.patch(endpoint, data=json.dumps(request_body, separators=(',', ':')))
         response.raise_for_status()
         logger.debug("Updated config for node ID: {}", node_id)
 

--- a/src/ducopy/rest/models.py
+++ b/src/ducopy/rest/models.py
@@ -193,7 +193,7 @@ class NodeInfo(BaseModel):
     Node: int
     General: NodeGeneralInfo
     NetworkDuco: NetworkDucoInfo | None
-    Ventilation: VentilationInfo | None
+    Ventilation: VentilationInfo = None
     Sensor: SensorData | None = Field(default=None)
 
 


### PR DESCRIPTION
DUCO part 0000-4715 (https://www.duco.eu/Wes/CDN/1/Attachments/technische-fiche-Buitentemperatuursensor-met-Power-Supply-(nl)_638696139228545646.pdf) does not have a "Ventilation" block in its "get /config/node/X" response. adjust the model so that not having a ventilation block is also valid.