### PR TITLE
no spaces in the patch payload, as the duco box does not accept them

### DIFF
--- a/src/ducopy/rest/client.py
+++ b/src/ducopy/rest/client.py
@@ -240,7 +240,7 @@ class APIClient:
         # Send PATCH request if validation passes
         endpoint = f"/config/nodes/{node_id}"
         logger.info("Sending PATCH request with body: {}", request_body)
-        response = self.session.patch(endpoint, json=request_body)
+        response = self.session.patch(endpoint, data=json.dumps(request_body, separators=(',', ':')))
         response.raise_for_status()
         logger.debug("Updated config for node ID: {}", node_id)
 


### PR DESCRIPTION
It seems that the patch request generated contains spaces that the DUCO box does not accept.

a command that triggers the issue at my place is
`ducopy update-config-node https://192.168.213.225 5 --config-json '{"RhSetPoint":"60"}'`

this patch fixes that issue.
