### PR TITLE
change NodeInfo model to support outdoor temperature sensor

### DIFF
--- a/src/ducopy/rest/models.py
+++ b/src/ducopy/rest/models.py
@@ -193,7 +193,7 @@ class NodeInfo(BaseModel):
     Node: int
     General: NodeGeneralInfo
     NetworkDuco: NetworkDucoInfo | None
-    Ventilation: VentilationInfo | None
+    Ventilation: VentilationInfo = None
     Sensor: SensorData | None = Field(default=None)
 
 


### PR DESCRIPTION
My DUCO box has a outdoor temperature sensor
DUCO part 0000-4715 (https://www.duco.eu/Wes/CDN/1/Attachments/technische-fiche-Buitentemperatuursensor-met-Power-Supply-(nl)_638696139228545646.pdf) 

the `get-nodes` command breaks, because the corresponding node in the json output does not have a "Ventilation" block in its response.

this patch addresses this.
it adjusts the model so that not having a ventilation block is also valid.