### PR TITLE
add timeout to super().request(). Ducobox may sometimes hang.

### DIFF
--- a/src/ducopy/rest/utils.py
+++ b/src/ducopy/rest/utils.py
@@ -150,7 +150,7 @@ class DucoUrlSession(requests.Session):
                 logger.debug(
                     "Sending {} request to URL: {} (attempt {}/{})", method.upper(), url, attempt + 1, max_retries
                 )
-                response = super().request(method, url, *args, **kwargs)
+                response = super().request(method, url, timeout=15, *args, **kwargs)
                 response.raise_for_status()
                 logger.info("Received {} response from {}", response.status_code, url)
                 return response


### PR DESCRIPTION
`DucoUrlSession` extends `requests.Session` but doesn't set timeouts on HTTP calls. When super().request() is called without a timeout parameter, requests can hang indefinitely.

This is observed in pull request [Sikerdebaard/hacs-ducobox-connector#39.](https://github.com/Sikerdebaard/hacs-ducobox-connector/pull/39)

Instead of adding lots of code to that library, let's address it at the source.

The timeout is set at 15 seconds. No strong opinions on what the timeout should be, except that it should ideally be below one minute and allow some lag of the ducobox. 

Please note that this issue can also occur without even using hacs-ducobox-connector, but just by using docupy itself. Or, more honestly, it occurs with the ducobox itself, which is sometimes not responsive. (I'll configure it to reboot frequently, but still the library should handle timeouts graceously).