### PR TITLE
feat: Enhance PyPI publishing with error handling and status reporting

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -259,11 +259,22 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
+        id: publish_to_pypi
         if: steps.version_check.outputs.changed == 'true'
+        continue-on-error: true
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: python -m twine upload dist/*
+
+      - name: Report PyPI publish status
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          if [ "${{ steps.publish_to_pypi.outcome }}" = "failure" ]; then
+            echo "WARNING: PyPI publish failed, but continuing to create GitHub release."
+          else
+            echo "PyPI publish completed successfully."
+          fi
 
       - name: Create and push tag
         if: steps.release_gate.outputs.should_release == 'true'


### PR DESCRIPTION
This pull request makes improvements to the automated release workflow by enhancing error handling and reporting for the PyPI publishing step. The main goal is to ensure that if publishing to PyPI fails, the workflow will continue to create a GitHub release, and the status of the PyPI publish attempt is clearly reported.

Enhancements to the release workflow:

* Added `continue-on-error: true` to the PyPI publishing step, allowing the workflow to proceed even if the publish fails.
* Introduced a new step to report the status of the PyPI publish, outputting a warning if it failed or confirming success, to improve visibility into the release process.
* Assigned an `id` to the PyPI publishing step (`publish_to_pypi`) so that its outcome can be referenced in subsequent steps.